### PR TITLE
Fix url pathing.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,8 +4,8 @@ title_short: 中文社区
 email: admin@opensuse.org
 description: openSUSE 中文社区主页，为您带来最新的 openSUSE 资讯，为中文用户的交流提供一席之地。
 copyright: '© 2011–2021 openSUSE 中文社区贡献者'
-baseurl: ""
-url: ""
+url: https://opensuse-zh.github.io
+baseurl: /page-opensuse-zh
 github_url: "https://github.com/openSUSE-zh/page-opensuse-zh"
 
 #piwik_site_id: 13


### PR DESCRIPTION
This will make 

<https://opensuse-zh.github.io/assets/css/chameleon.css> (404)

to become 

<https://opensuse-zh.github.io/page-opensuse-zh/assets/css/chameleon.css> (actually exist)

Then the styling problem solved.

openSUSE build the website in their own server, so they were set to null.

Learn more -> https://jekyllrb.com/docs/liquid/filters/